### PR TITLE
Updating to Use Text-Bison for Chatbot NL Translation

### DIFF
--- a/lab-06-genai-chatbot/chatbot.ipynb
+++ b/lab-06-genai-chatbot/chatbot.ipynb
@@ -122,7 +122,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "base_chain = VertexAI(model_name=\"text-bison@001\", temperature=0)"
+    "base_chain = VertexAI(model_name=\"text-bison\", max_output_tokens=2048, temperature=0)"
    ]
   },
   {
@@ -213,7 +213,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "23987ff7",
+   "id": "05e5c4a7-9821-4fe8-9b26-49dc96d89103",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -329,22 +329,26 @@
    "id": "0a1263e2",
    "metadata": {},
    "source": [
-    "We are defining our `chain` object, which combines Neo4j Q/A and Vertex AI's [code-bison](https://cloud.google.com/vertex-ai/docs/generative-ai/model-reference/code-generation) LLM.  When the user gives a query, it first goes through `GraphCypherQAChain`, which generates a Cypher query according to the rules in our prompt above.  That result set then goes to the `VertexAI` step of the chain, where the LLM is given the Neo4j result set and instructed to roll it into a natural language response."
+    "We define our `chain` object (specifically a`GraphCypherQAChain`) using two vertex AI LLMs:\n",
+    "* [code-bison](https://cloud.google.com/vertex-ai/docs/generative-ai/model-reference/code-generation) to translate user questions to Cypher queries\n",
+    "* [text-bison](https://cloud.google.com/vertex-ai/docs/generative-ai/model-reference/text)  to convert Cypher query results back to natural language for human-friendly responses. \n",
+    "\n",
+    "`GraphCypherQAChain` also takes a ‘Neo4jGraph’ so it can handle the chatbot process end-to-end, from taking the user question and translating to Cypher to executing the query, getting results, translating back to natural language, and returning to the user. \n"
    ]
   },
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "4ec96b22",
+   "id": "6f94866b-7729-46a5-85cb-c11fb364eefa",
    "metadata": {},
    "outputs": [],
    "source": [
-    "#creating the chain from VertexAI langchain object\n",
     "chain = GraphCypherQAChain.from_llm(\n",
-    "    VertexAI(model_name='code-bison@001',\n",
-    "            max_output_tokens=2048,\n",
-    "            temperature=0.0), graph=graph, verbose=True,\n",
-    "            cypher_prompt=CYPHER_GENERATION_PROMPT,\n",
+    "    graph=graph,\n",
+    "    cypher_llm=VertexAI(model_name='code-bison@001', max_output_tokens=2048, temperature=0.0),\n",
+    "    qa_llm=VertexAI(model_name='text-bison', max_output_tokens=2048, temperature=0.0),\n",
+    "    cypher_prompt=CYPHER_GENERATION_PROMPT,\n",
+    "    verbose=True,\n",
     "    return_intermediate_steps=True\n",
     ")"
    ]
@@ -464,7 +468,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "r5 = chain(\"\"\"Which fund manager under 200 million has similar investment strategy as Blackrock\"\"\")\n",
+    "r5 = chain(\"\"\"Which fund managers under 200 million have the most similar investment strategies to Blackrock? Return the top 10.\"\"\")\n",
     "print(f\"Final answer: {r5['result']}\")"
    ]
   },
@@ -523,10 +527,10 @@
     "from langchain.memory import ConversationBufferMemory\n",
     "\n",
     "memory = ConversationBufferMemory(memory_key = \"chat_history\", return_messages = True)\n",
-    "llm = VertexAI(model_name='code-bison@001', temperature=0.2)\n",
     "agent_chain = chain\n",
     "\n",
     "def chat_response(input_text,history):\n",
+    "\n",
     "    try:\n",
     "        return agent_chain.run(input_text)\n",
     "    except:\n",
@@ -541,12 +545,12 @@
     "                             chatbot = gr.Chatbot(height=500),\n",
     "                             undo_btn = None,\n",
     "                             clear_btn = \"\\U0001F5D1 Clear chat\",\n",
-    "                             examples = [\"Who are Tesla's top investors in last 3 months?\",\n",
-    "                                         \"What are the top 10 investments for Blackrock?\",\n",
+    "                             examples = [\"What are the top 10 investments for Blackrock?\",\n",
     "                                         \"Which manager owns FAANG stocks?\",\n",
     "                                         \"What are other top investments for fund managers investing in Exxon?\",\n",
     "                                         \"What are Vanguard's top investments by value for 2023?\",\n",
-    "                                         \"Who are the common investors between Tesla and Microsoft?\"])\n",
+    "                                         \"Who are the common investors between Tesla and Microsoft?\",\n",
+    "                                         \"Who are Tesla's top investors in last 3 months?\"])\n",
     "\n",
     "interface.launch(share=True)"
    ]
@@ -596,10 +600,16 @@
   }
  ],
  "metadata": {
+  "environment": {
+   "kernel": "neo4j_genai",
+   "name": "pytorch-gpu.1-13.m108",
+   "type": "gcloud",
+   "uri": "gcr.io/deeplearning-platform-release/pytorch-gpu.1-13:m108"
+  },
   "kernelspec": {
-   "display_name": "neo4j_genai (Local)",
+   "display_name": "neo4j_genai",
    "language": "python",
-   "name": "local-neo4j_genai"
+   "name": "neo4j_genai"
   },
   "language_info": {
    "codemirror_mode": {


### PR DESCRIPTION
This PR leverages new Langchain capabilities added here: https://github.com/langchain-ai/langchain/pull/9689 .  

Basically, this lets us conveniently use different LLMs for Cypher generation vs translation of query results back to natural language.  This is important as we want to use an LLM fine-tuned for code generation like `code-bison` when generating Cypher, but such an LLM will not do as well for translating results back to natural language.... instead we may want to use something like `text-bison`

Note that in this PR I am not tagging a stable text-bison release (via `text-bison@001`). This is because the latest untagged version seemed to improve response quality (the stable release was more verbose and in some cases only giving partial answers, like results like for question r5). As a result of this, there could be slightly less stability in responses over time.....we need to keep an eye on it and change over to the next tagged release when available